### PR TITLE
Remove unnecessary imports from other ckan extensions

### DIFF
--- a/ckanext/fulltext/fulltext_api.py
+++ b/ckanext/fulltext/fulltext_api.py
@@ -34,13 +34,9 @@ import ckan.logic.action.create as create
 import ckan.logic.action.update as update
 
 from ckan.model import Session
-from ckanext.spatial.lib import save_package_extent,validate_bbox, bbox_query
 from ckanext.fulltext.model.setup_fulltext_table import PackageFulltext
 from ckan.model.package_extra import PackageExtra
-from ckanext.harvest.plugin import Harvest
 
-from ckanext.spatial.lib import save_package_extent,validate_bbox, bbox_query
-from ckanext.spatial.model.package_extent import setup as setup_model
 from ckanext.fulltext.model.setup_fulltext_table import setup
 
 from hmbtg_config import getConfValue

--- a/ckanext/fulltext/plugin.py
+++ b/ckanext/fulltext/plugin.py
@@ -38,14 +38,10 @@ from ckan import logic
 from ckan.logic import get_action, ValidationError
 
 from ckan.model import Session
-from ckanext.spatial.lib import save_package_extent,validate_bbox, bbox_query
 
 from ckanext.fulltext.model.setup_fulltext_table import PackageFulltext
 from ckan.model.package_extra import PackageExtra
-from ckanext.harvest.plugin import Harvest
 
-from ckanext.spatial.lib import save_package_extent,validate_bbox, bbox_query
-from ckanext.spatial.model.package_extent import setup as setup_model
 from ckanext.fulltext.fulltext_api import get_functions
 from ckanext.fulltext.fulltext_api import _get_fulltext
 


### PR DESCRIPTION
As far as I can see these imports are not needed and they currently break the installation of this plugin, because we don't have the spatial extensions installed currently.
