### PR TITLE
Fix import and name of Tika_Wrapper_Singleton in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ You can set an option in the CKAN config file (hmbtg.ini) to specify extras fiel
 Parsing the fulltext is easy:
 
 ```python
- from tikaparser import TikaWrapperSingleton
+ from ckanext.fulltext.parser.tikaparser import Tika_Wrapper_Singleton
 
- tika_parser = TikaWrapperSingleton()
+ tika_parser = Tika_Wrapper_Singleton()
  fulltext = tika_parser.parse_with_tika('path_to_local_file_or_url')
 ```
 


### PR DESCRIPTION
For some reason this was not up-to-date, with the updated import statement I can successfully use the Tika parser and add content to CKAN.
